### PR TITLE
Downgrade to ethers 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@glif/filecoin-address": "^2.0.43",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "ethers": "^6.8.1",
+    "ethers": "^5",
     "lucide-react": "^0.292.0",
     "next": "14.0.2",
     "react": "^18",


### PR DESCRIPTION
Fixes #5, as discussed [here](https://filecoinproject.slack.com/archives/C04U4GPK3QR/p1701681679589379?thread_ts=1701680818.827729&cid=C04U4GPK3QR). We probably want to go in the opposite direction and just move to ethers 6, but it's less broken in the meantime...